### PR TITLE
[#5] Rework the Generator/Installer

### DIFF
--- a/lib/generators/galter_ir_exporter/install/install_generator.rb
+++ b/lib/generators/galter_ir_exporter/install/install_generator.rb
@@ -1,0 +1,17 @@
+require 'rails/generators'
+require 'rails/generators/active_record'
+
+module GalterIrExporter
+  class Install < Rails::Generators::Base
+    include ActiveRecord::Generators::Migration
+
+    source_root File.expand_path('../templates', __FILE__)
+
+    desc "galter_ir_exporter generator to create the required migrations"
+
+    # Setup the database migrations
+    def copy_migrations
+      migration_template "create_galter_ir_exporter_migration_survey_items.rb", "db/migrate/galter_ir_exporter_migration_survey_items.rb"
+    end
+  end
+end

--- a/lib/generators/galter_ir_exporter/install/templates/create_galter_ir_exporter_migration_survey_items.rb
+++ b/lib/generators/galter_ir_exporter/install/templates/create_galter_ir_exporter_migration_survey_items.rb
@@ -1,0 +1,12 @@
+class CreateGalterIrExporterMigrationSurveyItems < ActiveRecord::Migration
+  def change
+    create_table :galter_ir_exporter_migration_survey_items do |t|
+      t.string :object_id
+      t.string :object_class
+      t.text :object_title
+      t.integer :migration_status
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/lib/generators/galter_ir_exporter/install_generator.rb
+++ b/lib/generators/galter_ir_exporter/install_generator.rb
@@ -1,9 +1,0 @@
-module GalterIrExporter
-  class Install < Rails::Generators::Base
-    source_root File.expand_path('../templates', __FILE__)
-    # Setup the database migrations
-    def copy_migrations
-      rake 'galter_ir_exporter:install:migrations'
-    end
-  end
-end


### PR DESCRIPTION
Move the 'install_generator.rb' to new install directory. Add template
for db migration to be created on install. Require modules needed and 
include correct module. closes #5   